### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,8 @@
 ---
 name: Integration Tests
+permissions:
+  contents: read
+  id-token: write
 
 'on':
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/graysonkuhns/replay/security/code-scanning/1](https://github.com/graysonkuhns/replay/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the steps in the workflow, the following permissions are needed:
- `contents: read` for checking out the code.
- `id-token: write` for authenticating to Google Cloud using `google-github-actions/auth@v2`.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
