### PR TITLE
Parallelize integration tests across workers

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,6 +12,10 @@ jobs:
   e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      matrix:
+        worker: [0, 1, 2]
+    name: E2E Tests (Worker ${{ matrix.worker }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -35,16 +39,37 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          chmod +x ./run_tests.sh
-          PARALLEL_TESTS=10 ./run_tests.sh
+          chmod +x ./run_tests_subset.sh
+          PARALLEL_TESTS=10 WORKER_INDEX=${{ matrix.worker }} TOTAL_WORKERS=3 ./run_tests_subset.sh
         timeout-minutes: 50
+        env:
+          WORKER_INDEX: ${{ matrix.worker }}
+          TOTAL_WORKERS: 3
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-test-results
+          name: e2e-test-results-worker-${{ matrix.worker }}
           path: |
             *.log
             e2e_tests/*.log
           retention-days: 7
+
+  e2e-tests-summary:
+    name: E2E Tests Summary
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [ "${{ needs.e2e-tests.result }}" == "failure" ]; then
+            echo "One or more test workers failed"
+            exit 1
+          elif [ "${{ needs.e2e-tests.result }}" == "cancelled" ]; then
+            echo "Test run was cancelled"
+            exit 1
+          else
+            echo "All test workers completed successfully"
+          fi

--- a/.github/workflows/nightly-e2e-tests.yml
+++ b/.github/workflows/nightly-e2e-tests.yml
@@ -15,6 +15,10 @@ jobs:
   nightly-e2e-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    strategy:
+      matrix:
+        worker: [0, 1, 2]
+    name: Nightly E2E Tests (Worker ${{ matrix.worker }})
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,20 +42,23 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          chmod +x ./run_tests.sh
+          chmod +x ./run_tests_subset.sh
           # Capture test output to log file for issue creation
-          PARALLEL_TESTS=10 ./run_tests.sh 2>&1 | tee nightly-test-output.log
+          PARALLEL_TESTS=10 WORKER_INDEX=${{ matrix.worker }} TOTAL_WORKERS=3 ./run_tests_subset.sh 2>&1 | tee nightly-test-output-worker-${{ matrix.worker }}.log
         timeout-minutes: 50
+        env:
+          WORKER_INDEX: ${{ matrix.worker }}
+          TOTAL_WORKERS: 3
 
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: nightly-e2e-test-results-${{ github.run_number }}
+          name: nightly-e2e-test-results-${{ github.run_number }}-worker-${{ matrix.worker }}
           path: |
             *.log
             e2e_tests/*.log
-            nightly-test-output.log
+            nightly-test-output-worker-*.log
           retention-days: 30
 
       - name: Notify on failure
@@ -67,7 +74,7 @@ jobs:
             let testOutput = '';
             let failureSummary = '';
             try {
-              const logContent = fs.readFileSync('nightly-test-output.log', 'utf8');
+              const logContent = fs.readFileSync(`nightly-test-output-worker-${process.env.WORKER_INDEX}.log`, 'utf8');
               
               // Extract failure information from the log
               const lines = logContent.split('\n');
@@ -128,6 +135,129 @@ jobs:
             ${failureSummary}**Test Failure Output:**
             \`\`\`
             ${testOutput}
+            \`\`\`
+            
+            **Next Steps:**
+            1. Check the complete logs in the workflow artifacts: [Test Results](${runUrl}#artifacts)
+            2. Review the failing tests and error messages above
+            3. Run the failing tests locally to reproduce the issue
+            4. Fix the underlying issue and verify with local test runs
+            
+            This issue was automatically created by the nightly E2E test workflow.`;
+            
+            // Check if there's already an open issue for today's date
+            const issues = await github.rest.issues.listForRepo({
+              owner,
+              repo,
+              state: 'open',
+              labels: 'nightly-test-failure'
+            });
+            
+            const today = new Date().toISOString().split('T')[0];
+            const existingIssue = issues.data.find(issue => 
+              issue.title.includes(today)
+            );
+            
+            if (!existingIssue) {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ['nightly-test-failure', 'bug']
+              });
+            }
+
+  nightly-e2e-tests-summary:
+    name: Nightly E2E Tests Summary
+    runs-on: ubuntu-latest
+    needs: nightly-e2e-tests
+    if: always()
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: nightly-e2e-test-results-${{ github.run_number }}-worker-*
+          merge-multiple: true
+
+      - name: Check test results and create issue
+        if: needs.nightly-e2e-tests.result == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+            const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${context.runId}`;
+            
+            // Merge test outputs from all workers
+            let allTestOutput = '';
+            let allFailedTests = [];
+            let seenFailures = new Set();
+            
+            for (let worker = 0; worker < 3; worker++) {
+              try {
+                const logFile = `nightly-test-output-worker-${worker}.log`;
+                const logContent = fs.readFileSync(logFile, 'utf8');
+                
+                // Extract failure information from the log
+                const lines = logContent.split('\n');
+                const failureLines = [];
+                
+                for (let i = 0; i < lines.length; i++) {
+                  const line = lines[i];
+                  
+                  // Look for test failure patterns
+                  if (line.includes('--- FAIL:')) {
+                    const testMatch = line.match(/--- FAIL: (\w+)/);
+                    if (testMatch && !seenFailures.has(testMatch[1])) {
+                      allFailedTests.push(testMatch[1]);
+                      seenFailures.add(testMatch[1]);
+                      failureLines.push(`[Worker ${worker}] ${line}`);
+                    }
+                  } else if (line.trim().startsWith('dlr_test.go:') || 
+                            line.trim().startsWith('move_test.go:') ||
+                            line.trim().startsWith('e2e_tests/') ||
+                            line.includes('Error:') || 
+                            line.includes('Failed to') ||
+                            line.includes('rpc error:') ||
+                            line.includes('panic:') ||
+                            line.includes('exit status')) {
+                    failureLines.push(`[Worker ${worker}] ${line}`);
+                  }
+                }
+                
+                if (failureLines.length > 0) {
+                  allTestOutput += `\n### Worker ${worker} Failures:\n` + failureLines.join('\n');
+                }
+                
+              } catch (error) {
+                console.log(`Could not read test output log for worker ${worker}:`, error.message);
+              }
+            }
+            
+            // Limit the output to avoid GitHub API limits
+            const maxLength = 4000;
+            if (allTestOutput.length > maxLength) {
+              allTestOutput = '...\n' + allTestOutput.slice(allTestOutput.length - maxLength + 4);
+            }
+            
+            // Create failure summary
+            let failureSummary = '';
+            if (allFailedTests.length > 0) {
+              failureSummary = `**Failed Tests (${allFailedTests.length} total):** ${allFailedTests.join(', ')}\n\n`;
+            }
+            
+            // Create an issue if nightly tests fail
+            const title = `Nightly E2E Tests Failed - ${new Date().toISOString().split('T')[0]}`;
+            const body = `The nightly E2E tests failed on ${new Date().toISOString().split('T')[0]}.
+
+            **Run URL:** ${runUrl}
+            
+            **Run ID:** ${context.runId}
+            
+            ${failureSummary}**Test Failure Output:**
+            \`\`\`
+            ${allTestOutput || 'No test output available. Check the workflow artifacts for detailed logs.'}
             \`\`\`
             
             **Next Steps:**

--- a/run_tests_subset.sh
+++ b/run_tests_subset.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+set -e
+
+# Load environment variables from .env if available
+if [ -f .env ]; then
+  set -a
+  source .env
+  set +a
+fi
+
+if [ -z "$GCP_PROJECT" ]; then
+  echo "GCP_PROJECT environment variable must be set"
+  exit 1
+fi
+
+# Set default parallelism (can be overridden via PARALLEL_TESTS environment variable)
+PARALLEL_TESTS=${PARALLEL_TESTS:-10}
+
+# Build the replay binary
+echo "Building replay binary..."
+go build -o replay .
+if [ $? -ne 0 ]; then
+  echo "Failed to build replay binary"
+  exit 1
+fi
+
+# Export workspace root for tests to find the binary
+export REPLAY_WORKSPACE_ROOT=$(pwd)
+
+# Cleanup function to remove the binary
+cleanup() {
+  echo "Cleaning up..."
+  rm -f replay
+}
+
+# Set up trap to cleanup on exit
+trap cleanup EXIT
+
+# Check if we're running a subset of tests based on worker configuration
+if [ -n "$WORKER_INDEX" ] && [ -n "$TOTAL_WORKERS" ]; then
+  echo "Running as worker $WORKER_INDEX of $TOTAL_WORKERS"
+  
+  # Build the test discovery tool
+  echo "Building test discovery tool..."
+  go build -o discover_tests ./tools/discover_tests.go
+  go build -o distribute_tests ./tools/distribute_tests.go
+  
+  # Discover all tests and distribute to this worker
+  echo "Discovering tests..."
+  ALL_TESTS=$(./discover_tests ./e2e_tests)
+  TOTAL_TEST_COUNT=$(echo "$ALL_TESTS" | wc -l)
+  echo "Total tests found: $TOTAL_TEST_COUNT"
+  
+  # Get tests for this worker
+  WORKER_TESTS=$(echo "$ALL_TESTS" | ./distribute_tests $WORKER_INDEX $TOTAL_WORKERS)
+  WORKER_TEST_COUNT=$(echo "$WORKER_TESTS" | wc -l)
+  echo "Worker $WORKER_INDEX will run $WORKER_TEST_COUNT tests"
+  
+  # Clean up discovery tools
+  rm -f discover_tests distribute_tests
+  
+  # Build regex pattern for tests
+  if [ -n "$WORKER_TESTS" ]; then
+    # Convert test list to regex pattern
+    TEST_PATTERN=$(echo "$WORKER_TESTS" | paste -sd '|' -)
+    echo "Running tests matching pattern: $TEST_PATTERN"
+    go test -count 1 -v -timeout 45m -parallel ${PARALLEL_TESTS} ./e2e_tests -run "^($TEST_PATTERN)$"
+  else
+    echo "No tests assigned to this worker"
+    exit 0
+  fi
+elif [ $# -eq 0 ]; then
+  # Run all tests
+  echo "Running all tests in parallel (max ${PARALLEL_TESTS} concurrent tests)..."
+  go test -count 1 -v -timeout 45m -parallel ${PARALLEL_TESTS} ./e2e_tests
+else
+  # Run only the specified test
+  TEST_NAME=$1
+  echo "Running test: $TEST_NAME"
+  go test -count 1 -v -timeout 45m -parallel ${PARALLEL_TESTS} ./e2e_tests -run "$TEST_NAME"
+fi

--- a/tools/discover_tests.go
+++ b/tools/discover_tests.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <test-directory>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	testDir := os.Args[1]
+	tests, err := discoverTests(testDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error discovering tests: %v\n", err)
+		os.Exit(1)
+	}
+
+	for _, test := range tests {
+		fmt.Println(test)
+	}
+}
+
+func discoverTests(dir string) ([]string, error) {
+	var tests []string
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		// Skip directories and non-test files
+		if d.IsDir() || !strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+
+		// Skip testhelpers directory
+		if strings.Contains(path, "testhelpers/") {
+			return nil
+		}
+
+		// Parse the Go file
+		fileTests, err := getTestsFromFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to parse %s: %w", path, err)
+		}
+
+		tests = append(tests, fileTests...)
+		return nil
+	})
+
+	return tests, err
+}
+
+func getTestsFromFile(filename string) ([]string, error) {
+	src, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filename, src, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	var tests []string
+	for _, decl := range file.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok {
+			if strings.HasPrefix(fn.Name.Name, "Test") && fn.Recv == nil {
+				// Check if it's a proper test function (takes *testing.T)
+				if len(fn.Type.Params.List) == 1 {
+					if starExpr, ok := fn.Type.Params.List[0].Type.(*ast.StarExpr); ok {
+						if sel, ok := starExpr.X.(*ast.SelectorExpr); ok {
+							if sel.Sel.Name == "T" {
+								tests = append(tests, fn.Name.Name)
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return tests, nil
+}

--- a/tools/distribute_tests.go
+++ b/tools/distribute_tests.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <worker-index> <total-workers>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	workerIndex, err := strconv.Atoi(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid worker index: %v\n", err)
+		os.Exit(1)
+	}
+
+	totalWorkers, err := strconv.Atoi(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Invalid total workers: %v\n", err)
+		os.Exit(1)
+	}
+
+	if workerIndex < 0 || workerIndex >= totalWorkers {
+		fmt.Fprintf(os.Stderr, "Worker index must be between 0 and %d\n", totalWorkers-1)
+		os.Exit(1)
+	}
+
+	// Read all tests from stdin
+	var tests []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		tests = append(tests, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading tests: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Distribute tests across workers
+	workerTests := distributeTests(tests, workerIndex, totalWorkers)
+
+	// Output tests for this worker
+	for _, test := range workerTests {
+		fmt.Println(test)
+	}
+}
+
+// distributeTests divides tests evenly across workers
+func distributeTests(tests []string, workerIndex, totalWorkers int) []string {
+	totalTests := len(tests)
+	testsPerWorker := totalTests / totalWorkers
+	remainder := totalTests % totalWorkers
+
+	// Calculate start and end indices for this worker
+	start := workerIndex * testsPerWorker
+	if workerIndex < remainder {
+		// Workers with index < remainder get one extra test
+		start += workerIndex
+		testsPerWorker++
+	} else {
+		// Adjust for the extra tests distributed to earlier workers
+		start += remainder
+	}
+
+	end := start + testsPerWorker
+	if end > totalTests {
+		end = totalTests
+	}
+
+	return tests[start:end]
+}


### PR DESCRIPTION
Implement parallel integration test execution across multiple GitHub Actions workers to reduce overall test runtime.

The changes introduce a matrix strategy in the `e2e-tests.yml` and `nightly-e2e-tests.yml` workflows to run tests concurrently on 3 workers. New Go tools (`discover_tests.go`, `distribute_tests.go`) are used to dynamically assign a subset of tests to each worker, which are then executed by `run_tests_subset.sh` with a parallelism of 10. This significantly speeds up the test suite by distributing the workload. Summary jobs consolidate results and handle nightly failure reporting across all workers.

---
<a href="https://cursor.com/background-agent?bcId=bc-e78e1980-509b-471c-bb56-297bb1e874b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e78e1980-509b-471c-bb56-297bb1e874b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

